### PR TITLE
chore: update readme with deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Warning**
+> `test-listen` is deprecated. Please use [`async-listen`](https://github.com/vercel/async-listen) instead.
+
 # test-listen
 
 URLs with ephemeral ports. `async`/`await` ready.


### PR DESCRIPTION
Use https://github.com/vercel/async-listen instead